### PR TITLE
set RPMFusion openid server

### DIFF
--- a/rfpkgdb2client/__init__.py
+++ b/rfpkgdb2client/__init__.py
@@ -25,7 +25,8 @@ from six.moves import input, xrange
 
 import rpmfusion_cert
 from fedora.client import AuthError
-from fedora.client import OpenIdBaseClient
+from rfpkgdb2client.openidbaseclient import OpenIdBaseClient
+import re
 
 
 class NullHandler(logging.Handler):
@@ -47,6 +48,8 @@ FAS_URL = r'https://admin.rpmfusion.org/accounts'
 BZ_URL = r'https://bugzilla.rpmfusion.org/xmlrpc.cgi'
 KOJI_HUB = r'https://koji.rpmfusion.org/kojihub'
 CGIT_URL = r'http://pkgs.rpmfusion.org/cgit'
+RPMFUSION_OPENID_API = 'https://id.rpmfusion.org/api/v1/'
+RPMFUSION_OPENID_RE = re.compile(r'^http(s)?:\/\/id\.(|stg.|dev.)?rpmfusion\.org(/)?')
 
 
 class PkgDBException(Exception):
@@ -145,7 +148,7 @@ class PkgDB(OpenIdBaseClient):
         for it.
         '''
         if not self.is_logged_in:
-            super(PkgDB, self).login(username, password, otp=None)
+            super(PkgDB, self).login(username, password, otp=None, openid_api=RPMFUSION_OPENID_API, openid_re=RPMFUSION_OPENID_RE)
 
     def call_api(self, path, params=None, data=None):
         ''' call the API.

--- a/rfpkgdb2client/openidbaseclient.py
+++ b/rfpkgdb2client/openidbaseclient.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python2 -tt
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2013-2015  Red Hat, Inc.
+# This file is part of python-fedora
+#
+# python-fedora is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# python-fedora is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with python-fedora; if not, see <http://www.gnu.org/licenses/>
+#
+
+"""Base client for application relying on OpenID for authentication.
+
+.. moduleauthor:: Pierre-Yves Chibon <pingou@fedoraproject.org>
+.. moduleauthor:: Toshio Kuratomi <toshio@fedoraproject.org>
+.. moduleauthor:: Ralph Bean <rbean@redhat.com>
+
+.. versionadded: 0.3.35
+
+"""
+
+# :F0401: Unable to import : Disabled because these will either import on py3
+#   or py2 not both.
+# :E0611: No name $X in module: This was renamed in python3
+
+import json
+import logging
+import os
+
+import lockfile
+import requests
+import requests.adapters
+from requests.packages.urllib3.util import Retry
+from six.moves.urllib.parse import urljoin
+
+from functools import wraps
+from munch import munchify
+from kitchen.text.converters import to_bytes
+
+from fedora import __version__
+from fedora.client import (AuthError,
+                           LoginRequiredError,
+                           ServerError,
+                           UnsafeFileError,
+                           check_file_permissions)
+from rfpkgdb2client.openidproxyclient import (
+    OpenIdProxyClient, absolute_url, openid_login)
+
+log = logging.getLogger(__name__)
+
+b_SESSION_DIR = os.path.join(os.path.expanduser('~'), '.fedora')
+b_SESSION_FILE = os.path.join(b_SESSION_DIR, 'openidbaseclient-sessions.cache')
+
+
+def requires_login(func):
+    """
+    Decorator function for get or post requests requiring login.
+
+    Decorate a controller method that requires the user to be authenticated.
+    Example::
+
+        from rfpkgdb2client.openidbaseclient import requires_login
+
+        @requires_login
+        def rename_user(new_name):
+            user = new_name
+            # [...]
+    """
+    def _decorator(request, *args, **kwargs):
+        """ Run the function and check if it redirected to the openid form.
+        Or if we got a 403
+        """
+        output = func(request, *args, **kwargs)
+        if output and \
+                '<title>OpenID transaction in progress</title>' in output.text:
+            raise LoginRequiredError(
+                '{0} requires a logged in user'.format(output.url))
+        elif output.status_code == 403:
+            raise LoginRequiredError(
+                '{0} requires a logged in user'.format(output.url))
+        return output
+    return wraps(func)(_decorator)
+
+
+class OpenIdBaseClient(OpenIdProxyClient):
+
+    """ A client for interacting with web services relying on openid auth. """
+
+    def __init__(self, base_url, login_url=None, useragent=None, debug=False,
+                 insecure=False, openid_insecure=False, username=None,
+                 cache_session=True, retries=None, timeout=None,
+                 retry_backoff_factor=0):
+        """Client for interacting with web services relying on fas_openid auth.
+
+        :arg base_url: Base of every URL used to contact the server
+        :kwarg login_url: The url to the login endpoint of the application.
+            If none are specified, it uses the default `/login`.
+        :kwarg useragent: Useragent string to use.  If not given, default to
+            "Fedora OpenIdBaseClient/VERSION"
+        :kwarg debug: If True, log debug information
+        :kwarg insecure: If True, do not check server certificates against
+            their CA's.  This means that man-in-the-middle attacks are
+            possible against the `BaseClient`. You might turn this option on
+            for testing against a local version of a server with a self-signed
+            certificate but it should be off in production.
+        :kwarg openid_insecure: If True, do not check the openid server
+            certificates against their CA's.  This means that man-in-the-
+            middle attacks are possible against the `BaseClient`. You might
+            turn this option on for testing against a local version of a
+            server with a self-signed certificate but it should be off in
+            production.
+        :kwarg username: Username for establishing authenticated connections
+        :kwarg cache_session: If set to true, cache the user's session data on
+            the filesystem between runs
+        :kwarg retries: if we get an unknown or possibly transient error from
+            the server, retry this many times.  Setting this to a negative
+            number makes it try forever.  Defaults to zero, no retries.
+            Note that this can only be set during object initialization.
+        :kwarg timeout: A float describing the timeout of the connection. The
+            timeout only affects the connection process itself, not the
+            downloading of the response body. Defaults to 120 seconds.
+        :kwarg retry_backoff_factor: Exponential backoff factor to apply in
+            between retry attempts.  We will sleep for:
+
+                `{retry_backoff_factor}*(2 ^ ({number of failed retries} - 1))`
+
+            ...seconds inbetween attempts.  The backoff factor scales the rate
+            at which we back off.   Defaults to 0 (backoff disabled).
+            Note that this attribute can only be set at object initialization.
+        """
+
+        # These are also needed by OpenIdProxyClient
+        self.useragent = useragent or 'Fedora BaseClient/%(version)s' % {
+            'version': __version__}
+        self.base_url = base_url
+        self.login_url = login_url or urljoin(self.base_url, '/login')
+        self.debug = debug
+        self.insecure = insecure
+        self.openid_insecure = openid_insecure
+        self.retries = retries
+        self.timeout = timeout
+
+        # These are specific to OpenIdBaseClient
+        self.username = username
+        self.cache_session = cache_session
+        self.cache_lock = lockfile.FileLock(b_SESSION_FILE)
+
+        # Make sure the database for storing the session cookies exists
+        if cache_session:
+            self._initialize_session_cache()
+
+        # python-requests session.  Holds onto cookies
+        self._session = requests.session()
+
+        # Also hold on to retry logic.
+        # http://www.coglib.com/~icordasc/blog/2014/12/retries-in-requests.html
+        server_errors = [500, 501, 502, 503, 504, 506, 507, 508, 509, 599]
+        method_whitelist = Retry.DEFAULT_METHOD_WHITELIST.union(set(['POST']))
+        if retries is not None:
+            prefixes = ['http://', 'https://']
+            for prefix in prefixes:
+                self._session.mount(prefix, requests.adapters.HTTPAdapter(
+                    max_retries=Retry(
+                        total=retries,
+                        status_forcelist=server_errors,
+                        backoff_factor=retry_backoff_factor,
+                        method_whitelist=method_whitelist,
+                    ),
+                ))
+
+        # See if we have any cookies kicking around from a previous run
+        self._load_cookies()
+
+    def _initialize_session_cache(self):
+        # Note -- fallback to returning None on any problems as this isn't
+        # critical.  It just makes it so that we don't have to ask the user
+        # for their password over and over.
+        if not os.path.isdir(b_SESSION_DIR):
+            try:
+                os.makedirs(b_SESSION_DIR, mode=0o750)
+            except OSError as err:
+                log.warning('Unable to create {file}: {error}'.format(
+                    file=b_SESSION_DIR, error=err))
+                self.cache_session = False
+                return None
+
+    @requires_login
+    def _authed_post(self, url, params=None, data=None, **kwargs):
+        """ Return the request object of a post query."""
+        response = self._session.post(url, params=params, data=data, **kwargs)
+        return response
+
+    @requires_login
+    def _authed_get(self, url, params=None, data=None, **kwargs):
+        """ Return the request object of a get query."""
+        response = self._session.get(url, params=params, data=data, **kwargs)
+        return response
+
+    @requires_login
+    def _authed_put(self, url, params=None, data=None, **kwargs):
+        """ Return the request object of a put query."""
+        response = self._session.put(url, params=params, data=data, **kwargs)
+        return response
+
+    @requires_login
+    def _authed_delete(self, url, params=None, data=None, **kwargs):
+        """ Return the request object of a delete query."""
+        response = self._session.delete(url, params=params, data=data, **kwargs)
+        return response
+
+    def send_request(self, method, auth=False, verb='POST', **kwargs):
+        """Make an HTTP request to a server method.
+
+        The given method is called with any parameters set in req_params.  If
+        auth is True, then the request is made with an authenticated session
+        cookie.
+
+        :arg method: Method to call on the server.  It's a url fragment that
+            comes after the :attr:`base_url` set in :meth:`__init__`.
+        :kwarg auth: If True perform auth to the server, else do not.
+        :kwarg req_params: Extra parameters to send to the server.
+        :kwarg file_params: dict of files where the key is the name of the
+            file field used in the remote method and the value is the local
+            path of the file to be uploaded.  If you want to pass multiple
+            files to a single file field, pass the paths as a list of paths.
+        :kwarg verb: HTTP verb to use.  GET and POST are currently supported.
+            POST is the default.
+        """
+        # Decide on the set of auth cookies to use
+
+        method = absolute_url(self.base_url, method)
+
+        self._authed_verb_dispatcher = {(False, 'POST'): self._session.post,
+                                        (False, 'GET'): self._session.get,
+                                        (False, 'PUT'): self._session.put,
+                                        (False, 'DELETE'): self._session.delete,
+                                        (True, 'POST'): self._authed_post,
+                                        (True, 'GET'): self._authed_get,
+                                        (True, 'PUT'): self._authed_put,
+                                        (True, 'DELETE'): self._authed_delete}
+
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = self.timeout
+
+        try:
+            func = self._authed_verb_dispatcher[(auth, verb)]
+        except KeyError:
+            raise Exception('Unknown HTTP verb')
+
+        try:
+            output = func(method, **kwargs)
+        except LoginRequiredError:
+            raise AuthError()
+
+        try:
+            data = output.json()
+        except ValueError as e:
+            # The response wasn't JSON data
+            raise ServerError(
+                method, output.status_code, 'Error returned from'
+                ' json module while processing %(url)s: %(err)s\n%(output)s' %
+                {
+                    'url': to_bytes(method),
+                    'err': to_bytes(e),
+                    'output': to_bytes(output.text),
+                })
+
+        data = munchify(data)
+
+        return data
+
+    def login(self, username, password, otp=None, openid_api=None, openid_re=None):
+        """ Open a session for the user.
+
+        Log in the user with the specified username and password
+        against the FAS OpenID server.
+
+        :arg username: the FAS username of the user that wants to log in
+        :arg password: the FAS password of the user that wants to log in
+        :kwarg otp: currently unused.  Eventually a way to send an otp to the
+            API that the API can use.
+
+        """
+        if not username:
+            raise AuthError("Username may not be %r at login." % username)
+        if not password:
+            raise AuthError("Password required for login.")
+        # It looks like we're really doing this. Let's make sure that we don't
+        # collide various cookies, and clear every cookie we had up until now
+        # for this service.
+        self._session.cookies.clear()
+        self._save_cookies()
+
+        # print("openidbaseclient.py login with %s" % openid_api)
+        response = openid_login(
+            session=self._session,
+            login_url=self.login_url,
+            username=username,
+            password=password,
+            otp=otp,
+            openid_insecure=self.openid_insecure,
+            openid_api=openid_api, openid_re=openid_re)
+        self._save_cookies()
+        return response
+
+    @property
+    def session_key(self):
+        return "%s:%s" % (self.base_url, self.username or '')
+
+    def has_cookies(self):
+        return bool(self._session.cookies)
+
+    def _load_cookies(self):
+        if not self.cache_session:
+            return
+
+        try:
+            check_file_permissions(b_SESSION_FILE, True)
+        except UnsafeFileError as e:
+            log.debug('Current sessions ignored: {}'.format(str(e)))
+            return
+
+        try:
+            with self.cache_lock:
+                with open(b_SESSION_FILE, 'rb') as f:
+                    data = json.loads(f.read().decode('utf-8'))
+            for key, value in data[self.session_key]:
+                self._session.cookies[key] = value
+        except KeyError:
+            log.debug("No pre-existing session for %s" % self.session_key)
+        except IOError:
+            # The file doesn't exist, so create it.
+            log.debug("Creating %s", b_SESSION_FILE)
+            oldmask = os.umask(0o027)
+            with open(b_SESSION_FILE, 'wb') as f:
+                f.write(json.dumps({}).encode('utf-8'))
+            os.umask(oldmask)
+
+    def _save_cookies(self):
+        if not self.cache_session:
+            return
+
+        with self.cache_lock:
+            try:
+                check_file_permissions(b_SESSION_FILE, True)
+                with open(b_SESSION_FILE, 'rb') as f:
+                    data = json.loads(f.read().decode('utf-8'))
+            except UnsafeFileError as e:
+                log.debug('Clearing sessions: {}'.format(str(e)))
+                os.unlink(b_SESSION_FILE)
+                data = {}
+            except Exception:
+                log.warn("Failed to open cookie cache before saving.")
+                data = {}
+
+            oldmask = os.umask(0o027)
+            data[self.session_key] = self._session.cookies.items()
+            with open(b_SESSION_FILE, 'wb') as f:
+                f.write(json.dumps(data).encode('utf-8'))
+            os.umask(oldmask)
+
+
+__all__ = ('OpenIdBaseClient', 'requires_login')

--- a/rfpkgdb2client/openidproxyclient.py
+++ b/rfpkgdb2client/openidproxyclient.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python2 -tt
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2013-2014  Red Hat, Inc.
+# This file is part of python-fedora
+#
+# python-fedora is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# python-fedora is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with python-fedora; if not, see <http://www.gnu.org/licenses/>
+#
+"""Implement a class that sets up simple communication to a Fedora Service.
+
+.. moduleauthor:: Pierre-Yves Chibon <pingou@fedoraproject.org>
+.. moduleauthor:: Toshio Kuratomi <toshio@fedoraproject.org>
+
+.. versionadded: 0.3.35
+
+"""
+
+import copy
+import logging
+import re
+# For handling an exception that's coming from requests:
+import ssl
+import time
+
+from six.moves import http_client as httplib
+from six.moves.urllib.parse import quote, parse_qs, urljoin, urlparse
+
+# Hack, hack, hack around
+# the horror that is logging!
+# Verily, verliy, verily, verily
+# We should all use something better
+try:
+    # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, *args):
+            pass
+
+import requests
+
+#from munch import munchify
+from kitchen.text.converters import to_bytes
+# For handling an exception that's coming from requests:
+import urllib3
+
+from fedora import __version__
+from fedora.client import AuthError, ServerError, FedoraServiceError
+
+log = logging.getLogger(__name__)
+log.addHandler(NullHandler())
+
+OPENID_SESSION_NAME = 'FAS_OPENID'
+
+FEDORA_OPENID_API = 'https://id.fedoraproject.org/api/v1/'
+FEDORA_OPENID_RE = re.compile(r'^http(s)?:\/\/id\.(|stg.|dev.)?fedoraproject\.org(/)?')
+
+
+def _parse_response_history(response, openid_re):
+    """ Retrieve the attributes from the response history. """
+    data = {}
+    for r in response.history:
+        if openid_re.match(r.url):
+            parsed = parse_qs(urlparse(r.url).query)
+            for key, value in parsed.items():
+                data[key] = value[0]
+            break
+    return data
+
+
+def openid_login(session, login_url, username, password, otp=None,
+                 openid_insecure=False, openid_api=None , openid_re=None):
+    """ Open a session for the user.
+
+    Log in the user with the specified username and password
+    against the FAS OpenID server.
+
+    :arg session: Requests session object required to persist the cookies
+        that are created during redirects on the openid provider.
+    :arg login_url: The url to the login endpoint of the application.
+    :arg username: the FAS username of the user that wants to log in
+    :arg password: the FAS password of the user that wants to log in
+    :kwarg otp: currently unused.  Eventually a way to send an otp to the
+        API that the API can use.
+    :kwarg openid_insecure: If True, do not check the openid server
+        certificates against their CA's.  This means that man-in-the-middle
+        attacks are possible against the `BaseClient`. You might turn this
+        option on for testing against a local version of a server with a
+        self-signed certificate but it should be off in production.
+
+    """
+
+    if openid_api is None:
+        openid_api = FEDORA_OPENID_API
+    if openid_re is None:
+        openid_re = FEDORA_OPENID_RE
+
+    # Log into the service
+    response = session.get(
+        login_url, headers={'Accept': 'application/json'})
+
+    try:
+        data = response.json()
+        openid_url = data.get('server_url', None)
+        if not openid_re.match(openid_url):
+            raise FedoraServiceError(
+                'Un-expected openid provider asked: %s' % openid_url)
+    except:
+        # Some consumers (like pyramid_openid) return redirects with the
+        # openid attributes encoded in the url
+        if not openid_re.match(response.url):
+            raise FedoraServiceError(
+                'Un-expected openid provider asked: %s' % response.url)
+        data = _parse_response_history(response, openid_re)
+
+    # Contact openid provider
+    data['username'] = username
+    data['password'] = password
+    # Let's precise to FedOAuth that we want to authenticate with FAS
+    data['auth_module'] = 'fedoauth.auth.fas.Auth_FAS'
+    data['auth_flow'] = 'fedora'
+    if not 'openid.mode' in data:
+        data['openid.mode'] = 'checkid_setup'
+    response = session.post(
+        openid_api, data=data, verify=not openid_insecure)
+    if not bool(response):
+        raise ServerError(openid_api, response.status_code,
+                          'Error returned from our POST to ipsilon.')
+
+    output = response.json()
+
+    if not output['success']:
+        raise AuthError(output['message'])
+
+    response = session.post(output['response']['openid.return_to'],
+                            data=output['response'])
+
+    return response
+
+
+def absolute_url(beginning, end):
+    """ Join two urls parts if the last part does not start with the first
+    part specified """
+    if not end.startswith(beginning):
+        end = urljoin(beginning, end)
+    return end
+
+
+class OpenIdProxyClient(object):
+    # pylint: disable-msg=R0903
+    """
+    A client to a Fedora Service.  This class is optimized to proxy multiple
+    users to a service.  OpenIdProxyClient is designed to be usable by code
+    that creates a single instance of this class and uses it in multiple
+    threads. However it is not completely threadsafe.  See the information
+    on setting attributes below.
+
+    If you want something that can manage one user's connection to a Fedora
+    Service, then look into using :class:`~fedora.client.OpenIdBaseClient`
+    instead.
+
+    This class has several attributes.  These may be changed after
+    instantiation.  Please note, however, that changing these values when
+    another thread is utilizing the same instance may affect more than just
+    the thread that you are making the change in.  (For instance, changing
+    the debug option could cause other threads to start logging debug
+    messages in the middle of a method.)
+
+    .. attribute:: base_url
+
+        Initial portion of the url to contact the server.  It is highly
+        recommended not to change this value unless you know that no other
+        threads are accessing this :class:`OpenIdProxyClient` instance.
+
+    .. attribute:: useragent
+
+        Changes the useragent string that is reported to the web server.
+
+    .. attribute:: session_name
+
+        Name of the cookie that holds the authentication value.
+
+    .. attribute:: debug
+
+        If :data:`True`, then more verbose logging is performed to aid in
+        debugging issues.
+
+    .. attribute:: insecure
+
+        If :data:`True` then the connection to the server is not checked to be
+        sure that any SSL certificate information is valid.  That means that
+        a remote host can lie about who it is.  Useful for development but
+        should not be used in production code.
+
+    .. attribute:: retries
+
+        Setting this to a positive integer will retry failed requests to the
+        web server this many times.  Setting to a negative integer will retry
+        forever.
+
+    .. attribute:: timeout
+
+        A float describing the timeout of the connection. The timeout only
+        affects the connection process itself, not the downloading of the
+        response body. Defaults to 120 seconds.
+
+    """
+
+    def __init__(self, base_url, login_url=None, useragent=None,
+                 session_name='session', debug=False, insecure=False,
+                 openid_insecure=False, retries=None, timeout=None):
+        """Create a client configured for a particular service.
+
+        :arg base_url: Base of every URL used to contact the server
+        :kwarg login_url: The url to the login endpoint of the application.
+            If none are specified, it uses the default `/login`.
+        :kwarg useragent: useragent string to use.  If not given, default
+            to "Fedora ProxyClient/VERSION"
+        :kwarg session_name: name of the cookie to use with session handling
+        :kwarg debug: If True, log debug information
+        :kwarg insecure: If True, do not check server certificates against
+            their CA's.  This means that man-in-the-middle attacks are
+            possible against the `BaseClient`. You might turn this option
+            on for testing against a local version of a server with a
+            self-signed certificate but it should be off in production.
+        :kwarg openid_insecure: If True, do not check the openid server
+            certificates against their CA's.  This means that man-in-the-
+            middle attacks are possible against the `BaseClient`. You might
+            turn this option on for testing against a local version of a
+            server with a self-signed certificate but it should be off in
+            production.
+        :kwarg retries: if we get an unknown or possibly transient error
+            from the server, retry this many times.  Setting this to a
+            negative number makes it try forever.  Defaults to zero, no
+            retries.
+        :kwarg timeout: A float describing the timeout of the connection.
+            The timeout only affects the connection process itself, not the
+            downloading of the response body. Defaults to 120 seconds.
+
+        """
+        self.debug = debug
+        log.debug('proxyclient.__init__:entered')
+
+        # When we are instantiated, go ahead and silence the python-requests
+        # log.  It is kind of noisy in our app server logs.
+        if not debug:
+            requests_log = logging.getLogger("requests")
+            requests_log.setLevel(logging.WARN)
+
+        if base_url[-1] != '/':
+            base_url = base_url + '/'
+        self.base_url = base_url
+        self.login_url = login_url or urljoin(self.base_url, '/login')
+        self.domain = urlparse(self.base_url).netloc
+        self.useragent = useragent or 'Fedora ProxyClient/%(version)s' % {
+            'version': __version__}
+        self.session_name = session_name
+        self.insecure = insecure
+        self.openid_insecure = openid_insecure
+
+        # Have to do retries and timeout default values this way as BaseClient
+        # sends None for these values if not overridden by the user.
+        if retries is None:
+            self.retries = 0
+        else:
+            self.retries = retries
+        if timeout is None:
+            self.timeout = 120.0
+        else:
+            self.timeout = timeout
+        log.debug('proxyclient.__init__:exited')
+
+    def __get_debug(self):
+        """Return whether we have debug logging turned on.
+
+        :Returns: True if debugging is on, False otherwise.
+
+        """
+        if log.level <= logging.DEBUG:
+            return True
+        return False
+
+    def __set_debug(self, debug=False):
+        """Change debug level.
+
+        :kwarg debug: A true value to turn debugging on, false value to turn it
+            off.
+        """
+        if debug:
+            log.setLevel(logging.DEBUG)
+        else:
+            log.setLevel(logging.ERROR)
+
+    debug = property(__get_debug, __set_debug, doc="""
+    When True, we log extra debugging statements.  When False, we only log
+    errors.
+    """)
+
+    def send_request(self, method, verb='POST', req_params=None,
+                     auth_params=None, file_params=None, retries=None,
+                     timeout=None, headers=None):
+        """Make an HTTP request to a server method.
+
+        The given method is called with any parameters set in ``req_params``.
+        If auth is True, then the request is made with an authenticated
+        session cookie.  Note that path parameters should be set by adding
+        onto the method, not via ``req_params``.
+
+        :arg method: Method to call on the server.  It's a url fragment that
+            comes after the base_url set in __init__().  Note that any
+            parameters set as extra path information should be listed here,
+            not in ``req_params``.
+        :kwarg req_params: dict containing extra parameters to send to the
+            server
+        :kwarg auth_params: dict containing one or more means of
+            authenticating to the server.  Valid entries in this dict are:
+
+            :cookie: **Deprecated** Use ``session_id`` instead.  If both
+                ``cookie`` and ``session_id`` are set, only ``session_id``
+                will be used.  A ``Cookie.SimpleCookie`` to send as a
+                session cookie to the server
+            :session_id: Session id to put in a cookie to construct an
+                identity for the server
+            :username: Username to send to the server
+            :password: Password to use with username to send to the server
+            :httpauth: If set to ``basic`` then use HTTP Basic Authentication
+                to send the username and password to the server.  This may
+                be extended in the future to support other httpauth types
+                than ``basic``.
+
+            Note that cookie can be sent alone but if one of username or
+            password is set the other must as well.  Code can set all of
+            these if it wants and all of them will be sent to the server.
+            Be careful of sending cookies that do not match with the
+            username in this case as the server can decide what to do in
+            this case.
+        :kwarg file_params: dict of files where the key is the name of the
+            file field used in the remote method and the value is the local
+            path of the file to be uploaded.  If you want to pass multiple
+            files to a single file field, pass the paths as a list of paths.
+        :kwarg retries: if we get an unknown or possibly transient error
+            from the server, retry this many times.  Setting this to a
+            negative number makes it try forever.  Default to use the
+            :attr:`retries` value set on the instance or in :meth:`__init__`.
+        :kwarg timeout: A float describing the timeout of the connection.
+            The timeout only affects the connection process itself, not the
+            downloading of the response body. Defaults to the :attr:`timeout`
+            value set on the instance or in :meth:`__init__`.
+        :kwarg headers: A dictionary containing specific headers to add to
+            the request made.
+        :returns: A tuple of session_id and data.
+        :rtype: tuple of session information and data from server
+
+        """
+        log.debug('openidproxyclient.send_request: entered')
+
+        # parameter mangling
+        file_params = file_params or {}
+
+        # Check whether we need to authenticate for this request
+        session_id = None
+        username = None
+        password = None
+        if auth_params:
+            if 'session_id' in auth_params:
+                session_id = auth_params['session_id']
+            if 'username' in auth_params and 'password' in auth_params:
+                username = auth_params['username']
+                password = auth_params['password']
+            elif 'username' in auth_params or 'password' in auth_params:
+                raise AuthError(
+                    'username and password must both be set in auth_params'
+                )
+            if not (session_id or username):
+                raise AuthError(
+                    'No known authentication methods specified: set '
+                    '"cookie" in auth_params or set both username and '
+                    'password in auth_params')
+
+        # urljoin is slightly different than os.path.join().  Make sure
+        # method will work with it.
+        method = method.lstrip('/')
+        # And join to make our url.
+        url = urljoin(self.base_url, quote(method))
+
+        # Set standard headers
+        if headers:
+            if not 'User-agent' in headers:
+                headers['User-agent'] = self.useragent
+            if not 'Accept' in headers:
+                headers['Accept'] = 'application/json'
+        else:
+            headers = {
+                'User-agent': self.useragent,
+                'Accept': 'application/json',
+            }
+
+        # Files to upload
+        for field_name, local_file_name in file_params:
+            file_params[field_name] = open(local_file_name, 'rb')
+
+        cookies = requests.cookies.RequestsCookieJar()
+        # If we have a session_id, send it
+        if session_id:
+            # Anytime the session_id exists, send it so that visit tracking
+            # works.  Will also authenticate us if there's a need.  Note
+            # that there's no need to set other cookie attributes because
+            # this is a cookie generated client-side.
+            cookies.set(self.session_name, session_id)
+
+        complete_params = req_params or {}
+
+        auth = None
+        if username and password:
+            # OpenID login
+            resp, session = self.login(username, password, otp=None)
+            cookies = session.cookies
+
+        # If debug, give people our debug info
+        log.debug('Creating request %s', to_bytes(url))
+        log.debug('Headers: %s', to_bytes(headers, nonstring='simplerepr'))
+        if self.debug and complete_params:
+            debug_data = copy.deepcopy(complete_params)
+
+            if 'password' in debug_data:
+                debug_data['password'] = 'xxxxxxx'
+
+            log.debug('Data: %r', debug_data)
+
+        if retries is None:
+            retries = self.retries
+
+        if timeout is None:
+            timeout = self.timeout
+
+        num_tries = 0
+        while True:
+            try:
+                response = session.request(
+                    method=verb,
+                    url=url,
+                    data=complete_params,
+                    cookies=cookies,
+                    headers=headers,
+                    auth=auth,
+                    verify=not self.insecure,
+                    timeout=timeout,
+                )
+            except (requests.Timeout, requests.exceptions.SSLError) as err:
+                if isinstance(err, requests.exceptions.SSLError):
+                    # And now we know how not to code a library exception
+                    # hierarchy...  We're expecting that requests is raising
+                    # the following stupidity:
+                    # requests.exceptions.SSLError(
+                    #   urllib3.exceptions.SSLError(
+                    #     ssl.SSLError('The read operation timed out')))
+                    # If we weren't interested in reraising the exception with
+                    # full traceback we could use a try: except instead of
+                    # this gross conditional.  But we need to code defensively
+                    # because we don't want to raise an unrelated exception
+                    # here and if requests/urllib3 can do this sort of
+                    # nonsense, they may change the nonsense in the future
+                    if not (err.args and isinstance(
+                                err.args[0], urllib3.exceptions.SSLError)
+                            and err.args[0].args
+                            and isinstance(err.args[0].args[0], ssl.SSLError)
+                            and err.args[0].args[0].args
+                            and 'timed out' in err.args[0].args[0].args[0]):
+                        # We're only interested in timeouts here
+                        raise
+                log.debug('Request timed out')
+                if retries < 0 or num_tries < retries:
+                    num_tries += 1
+                    log.debug('Attempt #%s failed', num_tries)
+                    time.sleep(0.5)
+                    continue
+                # Fail and raise an error
+                # Raising our own exception protects the user from the
+                # implementation detail of requests vs pycurl vs urllib
+                raise ServerError(
+                    url, -1, 'Request timed out after %s seconds' % timeout)
+
+            # When the python-requests module gets a response, it attempts to
+            # guess the encoding using chardet (or a fork)
+            # That process can take an extraordinarily long time for long
+            # response.text strings.. upwards of 30 minutes for FAS queries to
+            # /accounts/user/list JSON api!  Therefore, we cut that codepath
+            # off at the pass by assuming that the response is 'utf-8'.  We can
+            # make that assumption because we're only interfacing with servers
+            # that we run (and we know that they all return responses
+            # encoded 'utf-8').
+            response.encoding = 'utf-8'
+
+            # Check for auth failures
+            # Note: old TG apps returned 403 Forbidden on authentication
+            # failures.
+            # Updated apps return 401 Unauthorized
+            # We need to accept both until all apps are updated to return 401.
+            http_status = response.status_code
+            if http_status in (401, 403):
+                # Wrong username or password
+                log.debug('Authentication failed logging in')
+                raise AuthError(
+                    'Unable to log into server.  Invalid '
+                    'authentication tokens.  Send new username and password'
+                )
+            elif http_status >= 400:
+                if retries < 0 or num_tries < retries:
+                    # Retry the request
+                    num_tries += 1
+                    log.debug('Attempt #%s failed', num_tries)
+                    time.sleep(0.5)
+                    continue
+                # Fail and raise an error
+                try:
+                    msg = httplib.responses[http_status]
+                except (KeyError, AttributeError):
+                    msg = 'Unknown HTTP Server Response'
+                raise ServerError(url, http_status, msg)
+            # Successfully returned data
+            break
+
+        # In case the server returned a new session cookie to us
+        new_session = session.cookies.get(self.session_name, '')
+
+        log.debug('openidproxyclient.send_request: exited')
+        #data = munchify(data)
+        return new_session, response
+
+
+__all__ = (OpenIdProxyClient,)


### PR DESCRIPTION
this is one copy of fedora.client.openidbaseclient and fedora.client.openidproxyclient to allow use RPMFusion openid server
while https://github.com/fedora-infra/python-fedora/pull/231 is not approved 